### PR TITLE
feat: add wrapper script interface for bag converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ cd bag_converter/docker
 
 # Example
 ```shell
-docker run -it --rm -v {YOUR_ROABAG_PATH}:/bag bag_converter:latest ros2 run bag_manipulate seyond_nebula_bag_decoder /bag/xxxx.mcap /bag/yyyy
+./bag_converter <path-to-intput-mcap> <path-to-output-mcap>
 ```

--- a/bag_converter
+++ b/bag_converter
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Check if Docker is installed
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: Docker is not installed. Please install Docker from https://docs.docker.com/engine/install/"
+    exit 1
+fi
+
+# Check if bag_converter:latest image exists
+if ! docker image inspect bag_converter:latest >/dev/null 2>&1; then
+    echo "Error: Docker image 'bag_converter:latest' not found. Please build it first by running: cd bag_converter/docker && ./build.sh"
+    exit 1
+fi
+
+# Check arguments
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <input_mcap_path> <output_mcap_path>"
+    exit 1
+fi
+
+INPUT_MCAP="$1"
+OUTPUT_MCAP="$2"
+
+# Check if input file exists
+if [ ! -f "$INPUT_MCAP" ]; then
+    echo "Error: Input file '$INPUT_MCAP' does not exist."
+    exit 1
+fi
+
+# Get absolute paths
+INPUT_ABS=$(realpath "$INPUT_MCAP")
+OUTPUT_ABS=$(realpath "$OUTPUT_MCAP")
+
+# Get directory paths for Docker volume mounting
+INPUT_DIR=$(dirname "$INPUT_ABS")
+OUTPUT_DIR=$(dirname "$OUTPUT_ABS")
+INPUT_FILE=$(basename "$INPUT_ABS")
+OUTPUT_FILE=$(basename "$OUTPUT_ABS")
+
+# Run the bag converter using Docker
+echo "Converting bag file: $INPUT_MCAP -> $OUTPUT_MCAP"
+docker run -it --rm \
+    -v "$INPUT_DIR":/input \
+    -v "$OUTPUT_DIR":/output \
+    bag_converter:latest \
+    ros2 run bag_manipulate seyond_nebula_bag_decoder /input/$INPUT_FILE /output/tmp
+mv $OUTPUT_DIR/tmp/tmp_0.mcap $OUTPUT_DIR/$OUTPUT_FILE
+rm -rf $OUTPUT_DIR/tmp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,30 @@
 FROM ubuntu:22.04
 
 # Re-declare ARG after FROM to use in RUN commands
-ARG ROS_DISTRO=humble
-
+ENV ROS_DISTRO=humble
 SHELL ["/bin/bash", "-c"]
 
 # Set timezone and locale
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 ENV LANG=en_US.UTF-8
+ARG USER_ID=9999
+ARG GROUP_ID=9999
+ARG USER_NAME=user
+ARG USER_HOME=/home/user
+
+# Create or modify a non-root user based on the provided UID/GID
+RUN set -eux; \
+    EXISTING_USER=$(getent passwd ${USER_ID} | cut -d: -f1 || true); \
+    EXISTING_GROUP=$(getent group ${GROUP_ID} | cut -d: -f1 || true); \
+    if [ -n "${EXISTING_USER}" ]; then \
+        usermod -l ${USER_NAME} ${EXISTING_USER}; \
+        groupmod -n ${USER_NAME} ${EXISTING_GROUP}; \
+    else \
+        groupadd -g ${GROUP_ID} ${USER_NAME}; \
+        useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME}; \
+    fi; \
+    cp /etc/skel/.bashrc ${USER_HOME}/.bashrc;
 
 # Install dependencies
 RUN apt update && \
@@ -48,7 +64,10 @@ RUN curl -sSL https://api.github.com/repos/ros-infrastructure/ros-apt-source/rel
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Set the working directory
 WORKDIR /opt/drs
+
+# Copy source code
 COPY src/ /opt/drs/src/
 
 # Initialize rosdep and install dependencies
@@ -64,10 +83,11 @@ RUN rosdep init && \
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to bag_manipulate
 
-ENV ROS_DISTRO=humble
-
 # Copy entrypoint
 ADD docker/entrypoint.sh /
-RUN chmod +x /entrypoint.sh
+RUN chown ${USER_ID}:${GROUP_ID} /entrypoint.sh && chmod +x /entrypoint.sh
+
+# Switch to the non-root user
+USER ${USER_NAME}
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Re-declare ARG after FROM to use in RUN commands
-ENV ROS_DISTRO=humble
+ARG ROS_DISTRO=humble
 SHELL ["/bin/bash", "-c"]
 
 # Set timezone and locale
@@ -82,6 +82,9 @@ RUN rosdep init && \
 # Build ROS packages
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to bag_manipulate
+
+# Set env var
+ENV ROS_DISTRO=${ROS_DISTRO}
 
 # Copy entrypoint
 ADD docker/entrypoint.sh /

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,6 +9,6 @@ cd ..
 echo "Building bag_converter Docker image..."
 
 # Build the image from parent directory
-docker build -t bag_converter:latest -f docker/Dockerfile .
+docker build -t bag_converter:latest -f docker/Dockerfile . --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)
 
 echo "Docker image built successfully: bag_converter:latest"


### PR DESCRIPTION
## Changes

- Add executable wrapper script for simplified usage
- Update README with new streamlined interface
- Configure Docker for non-root user execution
- Enhance build script with user ID/GID arguments


## Usage

`path-to-input-mcap`: 入力のmcapへのパス
`path-to-output-mcap`: 出力のmcapへのパス（保存先）
出力のmcapの権限はdocker imageをビルドしたユーザと一致するようになっています。

```
./bag_converter <path-to-intput-mcap> <path-to-output-mcap>
```